### PR TITLE
DF-7: Basic Slash Implementation

### DIFF
--- a/src/bot/bot_controller.py
+++ b/src/bot/bot_controller.py
@@ -1,5 +1,4 @@
 import os
-import gevent
 from sys import platform
 import subprocess
 from subprocess import Popen

--- a/src/bot/message_handler.py
+++ b/src/bot/message_handler.py
@@ -178,3 +178,36 @@ class Message_Handler:
             fn = self.command["fn"]
         self.fn = lambda: fn(self.message, self.args)
         return self.fn
+
+class From_Interaction:
+    def __init__(self, interaction, config) -> None:
+        self.config = config
+        self.id = interaction.id
+        self.channel = interaction.channel
+        self.created_at = interaction.created_at
+        self.author = interaction.user
+        self.guild = interaction.guild
+        self.command = interaction.data.get('name', '')
+        self.content = f'{self.config.prefix_keyword} {self.command} '
+        for text in interaction.data.get('options', []):
+            self.content+= text.get('value', '')
+        self.type = interaction.type
+        self.application_id = interaction.application_id
+        self.components = []
+        self.attachments = []
+        self.embeds = []
+        self.mention_everyone = False
+        self.mentions = []
+        self.nonce = None
+        self.pinned = False
+        self.reactions = []
+    
+    async def reply(self, *args, **kwargs):
+        return await self.channel.send( *args, **kwargs)
+    
+    async def edit(self, *args, **kwargs):
+        return await self.reply(*args, **kwargs)
+    
+    async def delete(self):
+        return True
+    


### PR DESCRIPTION
Implemented slash commands by creating a pseudo-message object that mimics a [discord.Message](https://discordpy.readthedocs.io/en/stable/api.html?highlight=message#discord.Message).

The translation is done via `From_Interaction` and takes an interaction object ([discord.Interaction](https://discordpy.readthedocs.io/en/stable/interactions/api.html?highlight=interaction#discord.Interaction)) of type `discord.InteractionType.application_command`.

After the interaction is converted to a "message" object, it is passed to the regular message handler `on_message`. From that point forward, it is treated as though it is a normal discord message object - which facilitates a simple compatibility layer with "Slash Commands".

Things that still need to be tested:
- All commands have been tested as a simple user. No edge cases have been accounted for. We need to hit every possible scenario and address any errors.

Things that could still use improvement:
- Unfortunately, Discord.py does not condone a simple slash command issued with no interaction response. Every slash command must always be responded to. Our current (and very hacky) implementation of a interaction.response.send_message() sends a silent/ephemeral throwaway message `"*...*"` after every slash command, then deletes it after 0.5 seconds. This appeases the interaction with no error, but can be an odd user experience.
- The way Slash/App Commands define their input parameters is by the parameter variable names being passed into the callback function. Since these callback functions don't actually do anything, it's a very obtrusive way of defining input parameters for our slash commands. We should find an alternative. Potentially not defining any parameters for our stub function, and finding a way to add them elsewhere OR dynamically generating a stub function that takes the exact parameters our command expects (as we loop through `MESSAGE_MAP`).

Things that can be added:
- Enable/disable slash commands from within the WebUI.
- Our current behavior is to enable slash commands globally without defining a guild ID. This works, but does not allow us to enable/disable slash commands based on server. This also makes dev/user experience sluggish, as changes to the global app command definition/registry within Discord's Servers take at least an hour to populate. We should be able to Enable/Disable slash commands per discord server and populate them instantly due to passing in a guild id to the sync function.
- Enable/disable slash commands per user.