### PR TITLE
API V3 UPDATE FOR SONARR

### DIFF
--- a/DiscoFlixBot/lib/api/sonarr.py
+++ b/DiscoFlixBot/lib/api/sonarr.py
@@ -12,7 +12,7 @@ class SonarrAPI(RequestAPI):
             api_key (str): API key from Sonarr.
         """
         super().__init__(host_url, api_key)
-        self.base = "/api"
+        self.base = "/api/v3"
 
     def get_calendar(
         self, start_date: Optional[str] = None, end_date: Optional[str] = None


### PR DESCRIPTION
Changed the base url for apiv3. Everything else seems to have remained the same for now - will continue monitoring for incompatible endpoints going forward.